### PR TITLE
Add SQLite example for storing images, names, and actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.db
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# faze
+# Faze
+
+This repository includes a simple Python example for storing images, names, and actions in an SQLite database.
+
+## Usage
+
+1. Ensure you have Python 3 installed.
+2. Run `python database.py` to create the `data.db` file.
+3. Insert images with:
+
+```python
+from pathlib import Path
+from database import insert_image
+
+insert_image("Alice", "Running", Path("alice.jpg"))
+```
+
+4. Retrieve records with:
+
+```python
+from database import fetch_all
+print(fetch_all())
+```

--- a/database.py
+++ b/database.py
@@ -1,0 +1,44 @@
+import sqlite3
+from pathlib import Path
+
+DB_PATH = Path('data.db')
+
+def initialize():
+    conn = sqlite3.connect(DB_PATH)
+    cursor = conn.cursor()
+    cursor.execute(
+        '''
+        CREATE TABLE IF NOT EXISTS photos (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            action TEXT NOT NULL,
+            image BLOB NOT NULL
+        )
+        '''
+    )
+    conn.commit()
+    conn.close()
+
+def insert_image(name: str, action: str, image_path: Path) -> None:
+    conn = sqlite3.connect(DB_PATH)
+    cursor = conn.cursor()
+    with open(image_path, 'rb') as f:
+        image_bytes = f.read()
+    cursor.execute(
+        'INSERT INTO photos (name, action, image) VALUES (?, ?, ?)',
+        (name, action, image_bytes)
+    )
+    conn.commit()
+    conn.close()
+
+def fetch_all():
+    conn = sqlite3.connect(DB_PATH)
+    cursor = conn.cursor()
+    cursor.execute('SELECT id, name, action, image FROM photos')
+    rows = cursor.fetchall()
+    conn.close()
+    return rows
+
+if __name__ == '__main__':
+    initialize()
+    print(f"Database initialized at {DB_PATH.resolve()}")


### PR DESCRIPTION
## Summary
- add `database.py` with utilities to store images, names, and actions in SQLite
- document usage in `README.md`
- ignore generated database and Python cache files

## Testing
- `python database.py`
- `python -m py_compile database.py && echo "py_compile success"`


------
https://chatgpt.com/codex/tasks/task_e_68c6980be168832e8391f6bb8a4512ad